### PR TITLE
replaced underscores with dashes in Group ID, to match Gradle Plugin ID

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   idea
 }
 
-group = "dev.adamko.kotlin.binary_compatibility_validator"
+group = "dev.adamko.kotlin.binary-compatibility-validator"
 project.version = object {
   private val gitVersion = project.gitVersion
   override fun toString(): String = gitVersion.get()

--- a/modules/bcv-gradle-plugin/build.gradle.kts
+++ b/modules/bcv-gradle-plugin/build.gradle.kts
@@ -103,3 +103,30 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 binaryCompatibilityValidator {
   ignoredMarkers.add("dev.adamko.kotlin.binary_compatibility_validator.internal.BCVInternalApi")
 }
+
+
+publishing {
+  publications {
+    register<MavenPublication>("relocation") {
+      pom {
+        val relocationMessage =
+          "Relocated artifact. Replaced underscores with dashes in the Group ID, to match BCV-MU's Gradle Plugin ID."
+        name = "Binary Compatibility Validator MU [RELOCATION MARKER]"
+        description = relocationMessage
+
+        // Old artifact coordinates
+        groupId = "dev.adamko.kotlin.binary_compatibility_validator"
+        artifactId = "bcv-gradle-plugin"
+
+        distributionManagement {
+          relocation {
+            // New artifact coordinates
+            groupId = project.group.toString()
+            artifactId = project.name
+            message = relocationMessage
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Rename group

* old: `dev.adamko.kotlin.binary_compatibility_validator`
* new: `dev.adamko.kotlin.binary-compatibility-validator`

Add Maven relocation information