### PR TITLE
GHA fix checkout-ref

### DIFF
--- a/.github/workflows/run_gradle_task.yml
+++ b/.github/workflows/run_gradle_task.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+          ref: ${{ inputs.checkout-ref || github.ref }}
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/run_publish_maven.yml
+++ b/.github/workflows/run_publish_maven.yml
@@ -41,4 +41,4 @@ jobs:
       runs-on: macos-latest # only macOS supports building all Kotlin targets
       gradle-task: >-
         publishAllPublicationsToSonatypeReleaseRepository --stacktrace --no-configuration-cache --no-parallel
-      checkout-ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+      checkout-ref: ${{ inputs.checkout-ref }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,4 +34,4 @@ jobs:
       runs-on: ${{ matrix.os }}
       gradle-task: >-
         ${{ matrix.task }} --stacktrace
-      checkout-ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+      checkout-ref: ${{ inputs.checkout-ref }}

--- a/.github/workflows/workflow_release.yml
+++ b/.github/workflows/workflow_release.yml
@@ -37,4 +37,4 @@ jobs:
       packages: write
       checks: write
     with:
-      checkout-ref: ${{ inputs.checkout-ref || github.event.repository.default_branch }}
+      checkout-ref: ${{ inputs.checkout-ref }}


### PR DESCRIPTION
Don't fall back to the main branch! Use the ref of the event that triggered the action (`github.ref`)